### PR TITLE
[workflows] remove sbom section from goreleaser config

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,4 +1,4 @@
-name: Go CI
+name: go ci build
 "on":
   push:
     branches:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,10 +23,10 @@ jobs:
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v5
         with:
-          # either 'goreleaser' (default) or 'goreleaser-pro'
           distribution: goreleaser
           version: latest
           args: release --clean
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # need to push to cacoco/homebrew-tap; use CACOCO_TOKEN instead of default GITHUB_TOKEN
+          GITHUB_TOKEN: ${{ secrets.CACOCO_TOKEN }} 
           GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -53,9 +53,6 @@ archives:
       - goos: windows
         format: zip
 
-sboms:
-  - artifacts: archive
-
 signs:
   - artifacts: checksum
     cmd: gpg2

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -55,7 +55,7 @@ archives:
 
 signs:
   - artifacts: checksum
-    cmd: gpg2
+    cmd: gpg
     args:
       - "--batch"
       - "-u"


### PR DESCRIPTION
requires `syft` to be installed. skip for now.