### PR TITLE
[feature] support loading file as base for codemeta editing

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,10 @@ codemetagenerator new
 ```
 
 This will walk you through an interactive session and will store an "in-progress" `codemeta.json` file. The expectation is that
-you will continue to add more metadata, e.g., `author`, `contributor`, or `keyword`.
+you will continue to add more metadata, e.g., `author`, `contributor`, or `keyword`. 
+
+Optionally, the `--input` (or `-i`) can be passed with a path to a file to load as the new in-progress `codemeta.json` file. This 
+allows for editing and updating an existing file which you can then choose to generate back into the original location.
 
 #### Add
 Add helps with the addition of 3 specific fields: `author`, `contributor`, or `keyword`. The command provides a wizard for adding these values. 

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -5,7 +5,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func generate(basedir string, writer utils.Writer, outputPath string) error {
+func generate(basedir string, writer utils.Writer, outFile string) error {
 	inProgressFilePath := utils.GetInProgressFilePath(basedir)
 
 	json, err := utils.ReadJSON(inProgressFilePath)
@@ -14,11 +14,11 @@ func generate(basedir string, writer utils.Writer, outputPath string) error {
 		return writer.Errorf("unable to read codemeta.inprogress.json file, ensure you have run `codemetagenerator new` at least once")
 	}
 
-	if outputPath != "" {
-		err = utils.WriteJSON(outputPath, *json)
+	if outFile != "" {
+		err = utils.WriteJSON(outFile, *json)
 		if err != nil {
 			handleErr(writer, err)
-			return writer.Errorf("unable to write codemeta.json file to output file %s", outputPath)
+			return writer.Errorf("unable to write codemeta.json file to output file %s", outFile)
 		}
 	} else {
 		writer.Println(*json)
@@ -27,7 +27,7 @@ func generate(basedir string, writer utils.Writer, outputPath string) error {
 	return nil
 }
 
-var codeMetaFilePath string
+var outputFile string
 
 // generateCmd represents the generate command
 var generateCmd = &cobra.Command{
@@ -40,12 +40,12 @@ Generate the resultant 'codemeta.json' file from the in-progress file.
 Output can be written to a file [-o | --output  <path/to/codemeta.json>] or 
 printed to the console.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return generate(utils.UserHomeDir, &utils.StdoutWriter{}, codeMetaFilePath)
+		return generate(utils.UserHomeDir, &utils.StdoutWriter{}, outputFile)
 	},
 }
 
 func init() {
 	rootCmd.AddCommand(generateCmd)
 
-	generateCmd.Flags().StringVarP(&codeMetaFilePath, "output", "o", "", "The path to the output 'codemeta.json' file. If not specified, the output will be printed to the console.")
+	generateCmd.Flags().StringVarP(&outputFile, "output", "o", "", "The path to the output 'codemeta.json' file. If not specified, the output will be printed to the console.")
 }

--- a/cmd/new.go
+++ b/cmd/new.go
@@ -1,13 +1,17 @@
 package cmd
 
 import (
+	"fmt"
+	"os"
+	"path/filepath"
+
 	"github.com/cacoco/codemetagenerator/internal/model"
 	"github.com/cacoco/codemetagenerator/internal/utils"
 	"github.com/manifoldco/promptui"
 	"github.com/spf13/cobra"
 )
 
-func new(basedir string, reader utils.Reader, writer utils.Writer) error {
+func new(basedir string, reader utils.Reader, writer utils.Writer, inFile string) error {
 	stdin := reader.Stdin()
 	stdout := writer.Stdout()
 
@@ -15,133 +19,151 @@ func new(basedir string, reader utils.Reader, writer utils.Writer) error {
 	inProgressFilePath := utils.GetInProgressFilePath(basedir)
 	utils.DeleteFile(inProgressFilePath)
 
-	var result = make(map[string]any)
-
-	identifier, err := utils.MkPrompt(&stdin, &stdout, "Enter a unique identifier for your software source code", utils.Nop)
-	if err != nil {
-		handleErr(writer, err)
-		return writer.Errorf("unable to create new identifier")
-	}
-
-	name, err := utils.MkPrompt(&stdin, &stdout, "Enter a name for your software source code", utils.Nop)
-	if err != nil {
-		handleErr(writer, err)
-		return writer.Errorf("unable to create new name")
-	}
-
-	description, err := utils.MkPrompt(&stdin, &stdout, "Enter a description for your software source code", utils.Nop)
-	if err != nil {
-		handleErr(writer, err)
-		return writer.Errorf("unable to create new description")
-	}
-
-	developmentStatusOptions := []model.MenuOption{
-		{Name: "Abandoned", Type: "abandoned"},
-		{Name: "Active", Type: "active"},
-		{Name: "Concept", Type: "concept"},
-		{Name: "Inactive", Type: "inactive"},
-		{Name: "Moved", Type: "moved"},
-		{Name: "Suspended", Type: "suspended"},
-		{Name: "Unsupported", Type: "unsupported"},
-		{Name: "WIP", Type: "wip"},
-	}
-
-	templates := &promptui.SelectTemplates{
-		Label:    "{{ . }}",
-		Active:   "➞ {{ .Name | cyan }}",
-		Inactive: "  {{ .Name | cyan }}",
-		Selected: `{{ "Select a development status (see: https://www.repostatus.org/):" | faint}} {{ .Name | faint }}`,
-		Details: `--------- Status ----------
-{{ "Name:" | faint }}	{{ .Name }}`,
-	}
-
-	prompt := promptui.Select{
-		Label:     "Select a development status from the list below (see: https://www.repostatus.org/)",
-		Items:     developmentStatusOptions,
-		Templates: templates,
-		Size:      8,
-		Searcher:  nil,
-		Stdin:     reader.Stdin(),
-		Stdout:    writer.Stdout(),
-	}
-
-	i, _, err := prompt.Run()
-	if err != nil {
-		return err
-	}
-	developmentStatus := developmentStatusOptions[i].Name
-
-	codeRepository, err := utils.MkPrompt(&stdin, &stdout, "Enter the URL of the code repository for the project", utils.ValidUrl)
-	if err != nil {
-		return err
-	}
-
-	programmingLanguageName, err := utils.MkPrompt(&stdin, &stdout, "Enter the name of the programming language of the project", utils.Nop)
-	if err != nil {
-		return err
-	}
-	programmingLanguageURL, err := utils.MkPrompt(&stdin, &stdout, "Enter the URL of the programming language of the project", utils.ValidUrl)
-	if err != nil {
-		return err
-	}
-	programmingLanguage := model.NewProgrammingLanguage(programmingLanguageName, programmingLanguageURL)
-
-	runtimePlatform, err := utils.MkPrompt(&stdin, &stdout, "Enter the name of the runtime platform of the project", utils.Nop)
-	if err != nil {
-		return err
-	}
-
-	version, err := utils.MkPrompt(&stdin, &stdout, "Enter the version of the project", utils.Nop)
-	if err != nil {
-		return err
-	}
-
-	validateFn := validateLicenseId(basedir)
-	license, err := utils.MkPrompt(&stdin, &stdout, "Enter the SPDX license ID for the project (see: https://spdx.org/licenses/)", validateFn)
-	if err != nil {
-		return err
-	}
-
-	var licenseDetailsUrl string
-	if (*license) != "" {
-		referenceUrl, err := getLicenseReference(basedir, *license)
+	var successMsg string = "⭐ Successfully created new in-progress codemeta.json file."
+	if inFile != "" {
+		bytes, err := utils.LoadFile(inFile)
 		if err != nil {
 			handleErr(writer, err)
-			return writer.Errorf("unable to create new license details URL")
+			return writer.Errorf("unable to read input file %s", inFile)
 		}
-		licenseDetailsUrl = *referenceUrl
+		err = os.WriteFile(inProgressFilePath, bytes, 0644)
+		if err != nil {
+			handleErr(writer, err)
+			return writer.Errorf("unable to write in-progress codemeta.json file")
+		}
+
+		fileBase := filepath.Base(inFile)
+		successMsg = fmt.Sprintf("⭐ Successfully loaded '%s' as new in-progress codemeta.json file.", fileBase)
+	} else {
+		var result = make(map[string]any)
+
+		identifier, err := utils.MkPrompt(&stdin, &stdout, "Enter a unique identifier for your software source code", utils.Nop)
+		if err != nil {
+			handleErr(writer, err)
+			return writer.Errorf("unable to create new identifier")
+		}
+
+		name, err := utils.MkPrompt(&stdin, &stdout, "Enter a name for your software source code", utils.Nop)
+		if err != nil {
+			handleErr(writer, err)
+			return writer.Errorf("unable to create new name")
+		}
+
+		description, err := utils.MkPrompt(&stdin, &stdout, "Enter a description for your software source code", utils.Nop)
+		if err != nil {
+			handleErr(writer, err)
+			return writer.Errorf("unable to create new description")
+		}
+
+		developmentStatusOptions := []model.MenuOption{
+			{Name: "Abandoned", Type: "abandoned"},
+			{Name: "Active", Type: "active"},
+			{Name: "Concept", Type: "concept"},
+			{Name: "Inactive", Type: "inactive"},
+			{Name: "Moved", Type: "moved"},
+			{Name: "Suspended", Type: "suspended"},
+			{Name: "Unsupported", Type: "unsupported"},
+			{Name: "WIP", Type: "wip"},
+		}
+
+		templates := &promptui.SelectTemplates{
+			Label:    "{{ . }}",
+			Active:   "➞ {{ .Name | cyan }}",
+			Inactive: "  {{ .Name | cyan }}",
+			Selected: `{{ "Select a development status (see: https://www.repostatus.org/):" | faint}} {{ .Name | faint }}`,
+			Details: `--------- Status ----------
+{{ "Name:" | faint }}	{{ .Name }}`,
+		}
+
+		prompt := promptui.Select{
+			Label:     "Select a development status from the list below (see: https://www.repostatus.org/)",
+			Items:     developmentStatusOptions,
+			Templates: templates,
+			Size:      8,
+			Searcher:  nil,
+			Stdin:     reader.Stdin(),
+			Stdout:    writer.Stdout(),
+		}
+
+		i, _, err := prompt.Run()
+		if err != nil {
+			return err
+		}
+		developmentStatus := developmentStatusOptions[i].Name
+
+		codeRepository, err := utils.MkPrompt(&stdin, &stdout, "Enter the URL of the code repository for the project", utils.ValidUrl)
+		if err != nil {
+			return err
+		}
+
+		programmingLanguageName, err := utils.MkPrompt(&stdin, &stdout, "Enter the name of the programming language of the project", utils.Nop)
+		if err != nil {
+			return err
+		}
+		programmingLanguageURL, err := utils.MkPrompt(&stdin, &stdout, "Enter the URL of the programming language of the project", utils.ValidUrl)
+		if err != nil {
+			return err
+		}
+		programmingLanguage := model.NewProgrammingLanguage(programmingLanguageName, programmingLanguageURL)
+
+		runtimePlatform, err := utils.MkPrompt(&stdin, &stdout, "Enter the name of the runtime platform of the project", utils.Nop)
+		if err != nil {
+			return err
+		}
+
+		version, err := utils.MkPrompt(&stdin, &stdout, "Enter the version of the project", utils.Nop)
+		if err != nil {
+			return err
+		}
+
+		validateFn := validateLicenseId(basedir)
+		license, err := utils.MkPrompt(&stdin, &stdout, "Enter the SPDX license ID for the project (see: https://spdx.org/licenses/)", validateFn)
+		if err != nil {
+			return err
+		}
+
+		var licenseDetailsUrl string
+		if (*license) != "" {
+			referenceUrl, err := getLicenseReference(basedir, *license)
+			if err != nil {
+				handleErr(writer, err)
+				return writer.Errorf("unable to create new license details URL")
+			}
+			licenseDetailsUrl = *referenceUrl
+		}
+
+		readme, err := utils.MkPrompt(&stdin, &stdout, "Enter the URL of the README file for the project", utils.ValidUrl)
+		if err != nil {
+			return err
+		}
+
+		maintainer, err := utils.NewPersonOrOrganizationPrompt(&reader, &writer, "Maintainer")
+		if err != nil {
+			return err
+		}
+
+		result[model.Identifier] = identifier
+		result[model.Name] = name
+		result[model.Description] = description
+		result[model.Version] = version
+		result[model.Maintainer] = maintainer
+		result[model.ProgrammingLanguage] = programmingLanguage
+		result[model.DevelopmentStatus] = developmentStatus
+		result[model.License] = licenseDetailsUrl
+		result[model.RuntimePlatform] = runtimePlatform
+		result[model.CodeRepository] = codeRepository
+		result[model.Readme] = readme
+
+		codemeta := model.NewCodemeta(&result)
+
+		err = utils.Marshal(inProgressFilePath, codemeta)
+		if err != nil {
+			handleErr(writer, err)
+			return writer.Errorf("unable to save in-progress codemeta.json file after editing")
+		}
 	}
 
-	readme, err := utils.MkPrompt(&stdin, &stdout, "Enter the URL of the README file for the project", utils.ValidUrl)
-	if err != nil {
-		return err
-	}
-
-	maintainer, err := utils.NewPersonOrOrganizationPrompt(&reader, &writer, "Maintainer")
-	if err != nil {
-		return err
-	}
-
-	result[model.Identifier] = identifier
-	result[model.Name] = name
-	result[model.Description] = description
-	result[model.Version] = version
-	result[model.Maintainer] = maintainer
-	result[model.ProgrammingLanguage] = programmingLanguage
-	result[model.DevelopmentStatus] = developmentStatus
-	result[model.License] = licenseDetailsUrl
-	result[model.RuntimePlatform] = runtimePlatform
-	result[model.CodeRepository] = codeRepository
-	result[model.Readme] = readme
-
-	codemeta := model.NewCodemeta(&result)
-
-	err = utils.Marshal(inProgressFilePath, codemeta)
-	if err != nil {
-		handleErr(writer, err)
-		return writer.Errorf("unable to save in-progress codemeta.json file after editing")
-	}
-	writer.Println("⭐ Successfully created new in-progress codemeta.json file.")
+	writer.Println(successMsg)
 	writer.Println("👇 You can now add authors, contributors, keywords, and other fields to the in-progress codemeta.json file.")
 	writer.Println("➡️  To add/remove authors, contributors or keywords, run the following commands:")
 	writer.Println("\tcodemetagenerator add author")
@@ -157,6 +179,8 @@ func new(basedir string, reader utils.Reader, writer utils.Writer) error {
 
 	return nil
 }
+
+var inputFile string
 
 // newCmd represents the new command
 var newCmd = &cobra.Command{
@@ -174,7 +198,7 @@ codemetagenerator generate
 
 to generate the resultant 'codemeta.json' file, optionally selecting the file destination.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return new(utils.UserHomeDir, &utils.StdinReader{}, &utils.StdoutWriter{})
+		return new(utils.UserHomeDir, &utils.StdinReader{}, &utils.StdoutWriter{}, inputFile)
 	},
 }
 
@@ -182,4 +206,6 @@ func init() {
 	rootCmd.AddCommand(newCmd)
 
 	utils.MkHomeDir(utils.UserHomeDir)
+
+	newCmd.Flags().StringVarP(&inputFile, "input", "i", "", "The path to an input 'codemeta.json' file. If not specified, a new file will be started.")
 }

--- a/cmd/new_test.go
+++ b/cmd/new_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func Test_ExecuteNewCmd(t *testing.T) {
+func Test_ExecuteNewCmd1(t *testing.T) {
 	g := gomega.NewWithT(t)
 
 	temp := t.TempDir()
@@ -61,7 +61,7 @@ func Test_ExecuteNewCmd(t *testing.T) {
 	writer := utils.TestWriter{}
 
 	new := &cobra.Command{Use: "new", RunE: func(cmd *cobra.Command, args []string) error {
-		return new(temp, &reader, &writer)
+		return new(temp, &reader, &writer, "")
 	},
 	}
 	buf := bytes.NewBufferString("")
@@ -99,6 +99,62 @@ func Test_ExecuteNewCmd(t *testing.T) {
 		model.RuntimePlatform:     "runtimePlatform",
 		model.CodeRepository:      "https://codeRepository.org",
 		model.Readme:              "https://readme.com",
+	}
+
+	g.Ω(m).Should(gomega.Equal(expected))
+}
+
+func Test_ExecuteNewCmd2(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	temp := t.TempDir()
+	// setup
+	os.Mkdir(utils.GetHomeDir(temp), 0755)
+	file, err := os.ReadFile("../testdata/spdx-licenses.json")
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	err = os.WriteFile(utils.GetLicensesFilePath(temp), file, 0644)
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	supportedLicenses, err := utils.GetSupportedLicenses(temp)
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	SupportedLicenses.setSupportedLicenses(*supportedLicenses)
+
+	reader := utils.TestReader{In: utils.TestStdin{Data: *utils.NilStack}}
+	writer := utils.TestWriter{}
+
+	new := &cobra.Command{Use: "new", RunE: func(cmd *cobra.Command, args []string) error {
+		return new(temp, &reader, &writer, "../testdata/testmeta.json")
+	},
+	}
+	buf := bytes.NewBufferString("")
+	new.SetOut(buf)
+	new.SetErr(buf)
+	new.SetArgs([]string{})
+
+	err = new.Execute()
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+
+	// check file
+	fileBytes, le := utils.LoadFile(utils.GetInProgressFilePath(temp))
+	if le != nil {
+		t.Errorf("Unexpected error: %v", le)
+	}
+	var m = make(map[string]any)
+	oj.Unmarshal(fileBytes, &m)
+
+	expected := map[string]any{
+		model.Context:     model.DefaultContext,
+		model.Type:        model.SoftwareSourceCodeType,
+		model.Identifier:  "testmeta",
+		model.Name:        "TestMeta",
+		model.Description: "A test codemeta.json file.",
 	}
 
 	g.Ω(m).Should(gomega.Equal(expected))

--- a/internal/utils/prompts.go
+++ b/internal/utils/prompts.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"net/mail"
 	"net/url"
+	"strings"
 
 	"github.com/cacoco/codemetagenerator/internal/model"
 	"github.com/manifoldco/promptui"
@@ -50,7 +51,6 @@ func MkPrompt(stdin *io.ReadCloser, stdout *io.WriteCloser, text string, validat
 		return nil, err
 	}
 
-	fmt.Fprint(*stdout, result)
 	return &result, nil
 }
 
@@ -66,7 +66,7 @@ func NewPersonOrOrganizationPrompt(reader *Reader, writer *Writer, label string)
 		Label:    "{{ . }}",
 		Active:   "➞ {{ .Name | cyan }}",
 		Inactive: "  {{ .Name | cyan }}",
-		Selected: "{{ .Name | red | cyan }}",
+		Selected: fmt.Sprintf(`{{ "Selected %s type:" | faint}} {{ .Name | faint }}`, strings.ToLower(label)),
 		Details: fmt.Sprintf(`--------- %s ----------
 {{ "Name:" | faint }}	{{ .Name }}`, label),
 	}

--- a/testdata/testmeta.json
+++ b/testdata/testmeta.json
@@ -1,0 +1,7 @@
+{
+    "@context": "https://w3id.org/codemeta/3.0",
+    "@type": "SoftwareSourceCode",
+    "identifier": "testmeta",
+    "description": "A test codemeta.json file.",
+    "name": "TestMeta"
+}


### PR DESCRIPTION
Update the `new` command to take an optional `--input` flag which denotes a file to use as the basis of the in-progess `codemeta.json` file. Allows for starting with data rather than creating from scratch with `new`.

Closes #37