### PR TITLE
[codecov] Fix configuration

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,6 +28,7 @@ jobs:
         run: cat TestResults.json
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v4.0.1
-        env:
+        with:
+          files: ./TestResults.json
           token: ${{ secrets.CODECOV_TOKEN }}
           slug: cacoco/codemetagenerator


### PR DESCRIPTION
The codecov instructions they give you to copy have a typo preventing the integration from working. After reading the docs, let's update `env` to be `with`.