### PR TITLE
[codecov] update how tests are run for coverage

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,10 +22,7 @@ jobs:
       - name: Build
         run: go build -v ./...
       - name: Test
-        run: go test ./... -cover -json > TestResults.json
-      - name: Cat results
-        if: always()
-        run: cat TestResults.json
+        run: go test ./... -race -coverprofile=coverage.out -covermode=atomic
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v4.0.1
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,6 +26,5 @@ jobs:
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v4.0.1
         with:
-          files: ./TestResults.json
           token: ${{ secrets.CODECOV_TOKEN }}
           slug: cacoco/codemetagenerator

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,7 +22,7 @@ jobs:
       - name: Build
         run: go build -v ./...
       - name: Test
-        run: go test ./... -race -coverprofile=coverage.out -covermode=atomic
+        run: go test ./... -coverprofile=coverage.out -covermode=atomic
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v4.0.1
         with:


### PR DESCRIPTION
Previous output is not recognized by codecov.io, switching as per example here: https://about.codecov.io/blog/getting-started-with-code-coverage-for-golang/